### PR TITLE
Set empty relations as loaded.

### DIFF
--- a/src/ElasticquentTrait.php
+++ b/src/ElasticquentTrait.php
@@ -724,6 +724,12 @@ trait ElasticquentTrait
                         // Unset attribute before match relation
                         unset($model[$key]);
                         $relation->match([$model], $models, $key);
+                        
+                        // The match method doesn't set the relation as loaded if the $models collection is empty
+                        // Set the relation as loaded manually and avoid future database queries
+                        if ((count($value) == 1 && reset($value) === null) || empty($value)) {
+                            $model->setRelation($key, empty($value) ? new Collection() : null);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Set the relations as loaded although the related models field is empty on the elastic document. This prevents future queries when accessing the relationship via the magic __get method.
